### PR TITLE
Fix #6 (Orechids don't stay connected to mana pool)

### DIFF
--- a/src/main/java/com/towboat/morechids/block/subtile/CustomOrechidSubtile.java
+++ b/src/main/java/com/towboat/morechids/block/subtile/CustomOrechidSubtile.java
@@ -260,6 +260,7 @@ public class CustomOrechidSubtile extends SubTileFunctional implements SubTileSi
 
     @Override
     public void readFromPacketNBT(NBTTagCompound cmp) {
+        super.readFromPacketNBT(cmp);
         positionAt = cmp.getInteger(TAG_POSITION);
 
         if(supertile.getWorld() != null && !supertile.getWorld().isRemote)
@@ -269,6 +270,7 @@ public class CustomOrechidSubtile extends SubTileFunctional implements SubTileSi
 
     @Override
     public void writeToPacketNBT(NBTTagCompound cmp) {
+        super.writeToPacketNBT(cmp);
         cmp.setInteger(TAG_POSITION, positionAt);
         for(int i = 0; i < ticksRemaining.length; i++)
             cmp.setInteger(TAG_TICKS_REMAINING + i, ticksRemaining[i]);


### PR DESCRIPTION
The current read/writeToPacketNBT overrides the functionality in SubTileFunctional that normally handles the mana pool linking.  I've made it call the read/write function that exists in the superclass so that it extends the functionality instead of just overriding it.  